### PR TITLE
squashed addition of email unsubscription

### DIFF
--- a/app/controllers/temperature_checks_controller.rb
+++ b/app/controllers/temperature_checks_controller.rb
@@ -12,6 +12,18 @@ class TemperatureChecksController < ApplicationController
   # def show
   # end
 
+
+  def unsubscribe
+    if params[:email]
+      @tracker = TrackerReminder.find_by_email(params[:email])
+      @tracker.is_unsubscribed = true
+      @tracker.save!
+      @email = @tracker.email
+    else
+
+    end
+  end
+
   # GET /temperature_checks/new
   def new
     @temperature_check = TemperatureCheck.new

--- a/app/models/tracker_reminder.rb
+++ b/app/models/tracker_reminder.rb
@@ -11,6 +11,7 @@ class TrackerReminder < ApplicationRecord
 
   def self.check_to_send
     TrackerReminder.all.each do |reminder|
+      next if reminder.is_unsubscribed
       mail = DailyTemperatureCheckMailer.with(daily_temperature_check: reminder).temperature_check
       mail.deliver_later
     end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -126,7 +126,7 @@
                         <tr>
                           <td valign="middle" class="bodyContent">
                             <div>
-                              &nbsp;<a href="#" target="_blank">view this in your browser</a> | <a href="#">unsubscribe from this list</a> | <a href="#">update subscription preferences</a>&nbsp;
+                              &nbsp;<a href="http://nationalfevertracker.com/unsubscribe">Unsubscribe from this list</a>&nbsp;
                             </div>
                           </td>
                         </tr>

--- a/app/views/temperature_checks/unsubscribe.html.erb
+++ b/app/views/temperature_checks/unsubscribe.html.erb
@@ -1,0 +1,19 @@
+<% if @email %>
+  <h1>You have been unsubscribed</h1>
+
+  <p>Email: <%= @email %></p>
+
+  <h2>If you have any issues, pleae email me directly at rememberlenny@gmail.com or contact me at (949)322-8496</h2>
+<% else %>
+  <div style="text-align: center">
+    <h3>Enter your email below to be unsubscribed</h3>
+      <%= form_with url: unsubscribe_path, method: 'post', local: true do %>
+        <div style="background: black; display: inline-block; padding: 1px;">
+          <%= text_field_tag(:email) %>      
+        </div>
+        <%= submit_tag("Submit") %>
+      <% end %>
+  </div>
+
+  <h2>If you have any issues, pleae email me directly at rememberlenny@gmail.com or contact me at (949)322-8496</h2>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   resources :tracker_reminders, only: [:new, :create]
   resources :temperature_checks, only: [:new, :create]
 
+  match "/unsubscribe", via: :all, to: "temperature_checks#unsubscribe", as: :unsubscribe
+  
   # Jumpstart views
   if Rails.env.development? || Rails.env.test?
     mount Jumpstart::Engine, at: '/jumpstart'

--- a/db/migrate/20200510063800_add_unsubscribe_to_tracker_reminder.rb
+++ b/db/migrate/20200510063800_add_unsubscribe_to_tracker_reminder.rb
@@ -1,0 +1,5 @@
+class AddUnsubscribeToTrackerReminder < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tracker_reminders, :is_unsubscribed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_185251) do
+ActiveRecord::Schema.define(version: 2020_05_10_063800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,6 +226,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_185251) do
     t.boolean "sore_throat", default: false, null: false
     t.boolean "difficulty_breathing", default: false, null: false
     t.boolean "fatigue", default: false, null: false
+    t.boolean "is_unsubscribed", default: false
   end
 
   create_table "tracker_reminders", force: :cascade do |t|
@@ -235,6 +236,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_185251) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "age"
     t.string "loc_zip"
+    t.boolean "is_unsubscribed", default: false
   end
 
   create_table "user_connected_accounts", force: :cascade do |t|


### PR DESCRIPTION
@rememberlenny added email unsubscription at https://github.com/rememberlenny/national-fever-tracker in `4a30f06..3887698`. I squashed these into one commit and cherry-picked it onto production. This should incorporate his changes with those we've made.